### PR TITLE
fix: AWS token refresh

### DIFF
--- a/engi-server/Async/EngineResponseDequeueService.cs
+++ b/engi-server/Async/EngineResponseDequeueService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Amazon.Runtime;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using Engi.Substrate.Jobs;
@@ -40,7 +41,11 @@ public class EngineResponseDequeueService : BackgroundService
             config.ServiceURL = awsOptions.ServiceUrl;
         }
 
-        var sqs = new AmazonSQSClient(config);
+        var credentials = string.IsNullOrEmpty(engiOptions.AssumeRole)
+            ? FallbackCredentialsFactory.GetCredentials()
+            : new InstanceProfileAWSCredentials(engiOptions.AssumeRole);
+
+        var sqs = new AmazonSQSClient(credentials, config);
 
         while (!stoppingToken.IsCancellationRequested)
         {

--- a/engi-server/Async/QueueEngineRequestCommandService.cs
+++ b/engi-server/Async/QueueEngineRequestCommandService.cs
@@ -1,8 +1,10 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
+using Amazon.Util;
 using Engi.Substrate.Jobs;
 using Microsoft.Extensions.Options;
 using Raven.Client.Documents;
@@ -55,7 +57,11 @@ public class QueueEngineRequestCommandService : SubscriptionProcessingBase<Queue
             config.ServiceURL = awsOptions.ServiceUrl;
         }
 
-        var client = new AmazonSimpleNotificationServiceClient(config);
+        var credentials = string.IsNullOrEmpty(engiOptions.AssumeRole)
+            ? FallbackCredentialsFactory.GetCredentials()
+            : new InstanceProfileAWSCredentials(engiOptions.AssumeRole);
+
+        var client = new AmazonSimpleNotificationServiceClient(credentials, config);
 
         using var session = batch.OpenAsyncSession();
 

--- a/engi-server/EngiOptions.cs
+++ b/engi-server/EngiOptions.cs
@@ -5,6 +5,11 @@ namespace Engi.Substrate.Server;
 public class EngiOptions
 {
     /// <summary>
+    /// Assume a role when using AWS services.
+    /// </summary>
+    public string? AssumeRole { get; set; }
+
+    /// <summary>
     /// The encryption certificate to use to store keys.
     /// </summary>
     public string EncryptionCertificate { get; set; } = null!;
@@ -19,7 +24,7 @@ public class EngiOptions
     /// </summary>
     public bool DisableChainObserver { get; set; }
 
-    ///
+    /// <summary>
     ///  Used to disable integration with Engine during testing.
     /// </summary>
     public bool DisableEngineIntegration { get; set; }


### PR DESCRIPTION
I hope that this will fix all token related sentries:

https://sentry.io/organizations/engi-bn/issues/3761425992/events/8f970168239a46a79837ca2a693ed071/?project=6440831

However, since the problem is related to the specific configuration I am not able to test this locally. We'll need to coordinate with @mholcombengi to somehow test this.

fixes ENGIN-903

References:
https://aws.amazon.com/premiumsupport/knowledge-center/ec2-expired-token/
https://stackoverflow.com/questions/35685729/the-security-token-included-in-the-request-is-expired
https://stackoverflow.com/questions/36732171/sqs-expiredtoken-the-security-token-included-in-the-request-is-expired-status-c

